### PR TITLE
Position passed to drop handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Out of the box this plugin does nothing with draggable rows - instead it raise a
 
 ```js
 $scope.gridOptions.onRegisterApi = function (gridApi) {
-    gridApi.draggableRows.on.rowDropped($scope, function (droppedRow, target) {
+    gridApi.draggableRows.on.rowDropped($scope, function (droppedRow, target, position) {
         // Now you can update the position or do something else
         // droppedRow and target variables are DOM elements
         // to extract row id just use getAttrbiute("draggable-id")
@@ -44,7 +44,7 @@ $scope.gridOptions.onRegisterApi = function (gridApi) {
         var droppedId = droppedRow.getAttribute("draggable-id");
         var targetId = target.getAttribute("draggable-id");
 
-        console.log("Dropped");
+        console.log("Dropped", position);
     });
 };
 ```
@@ -68,24 +68,33 @@ If you are using clear css just put these styles into your stylesheet.
 }
 
 .ui-grid-draggable-row-over:before {
-    content: ' ';
+    content: "";
     display: block;
-    padding-top: 5px;
-    height: 10px;
-    border: 1px dashed #AAA;
+    position: absolute;
+    left: 0;
+    width: 100%;
+    border-bottom: 1px dashed #AAA;
+}
+
+.ui-grid-draggable-row-over--above:before {
+    top: 0;
+}
+
+.ui-grid-draggable-row-over--below:before {
+    bottom: 0;
 }
 ```
 
 ## List of events
 
-| Event         | Listener                     | Original event   | Description                                 |
-|---------------|------------------------------|------------------|---------------------------------------------|
-| rowDragged    | function(draggedRow)         | onDragStart      | Fired once during start dragging            |
-| rowEnterRow   | function(draggedRow, row)    | onDragEnter      | Fired when draggable row enter on other row |
-| rowOverRow    | function(draggedRow, row)    | onDragOver       | Fired when draggable row is over other row  |
-| rowLeavesRow  | function(draggedRow, row)    | onDragLeave      | Fired when draggable row leaves other row   |
-| rowFinishDrag | function()                   | onDragEnd        | Fired after finish dragging                 |
-| rowDropped    | function(droppedRow, target) | onDrop           | Fired when row is dropping to other row     |
+| Event         | Listener                               | Original event   | Description                                 |
+|---------------|----------------------------------------|------------------|---------------------------------------------|
+| rowDragged    | function(draggedRow)                   | onDragStart      | Fired once during start dragging            |
+| rowEnterRow   | function(draggedRow, row)              | onDragEnter      | Fired when draggable row enter on other row |
+| rowOverRow    | function(draggedRow, row)              | onDragOver       | Fired when draggable row is over other row  |
+| rowLeavesRow  | function(draggedRow, row)              | onDragLeave      | Fired when draggable row leaves other row   |
+| rowFinishDrag | function()                             | onDragEnd        | Fired after finish dragging                 |
+| rowDropped    | function(droppedRow, target, position) | onDrop           | Fired when row is dropping to other row     |
 
 To listen these events just register new listener via _ui-grid_ API.
 

--- a/js/draggable-rows.js
+++ b/js/draggable-rows.js
@@ -13,7 +13,7 @@
         publicEvents: {
             draggableRows: {
                 rowDragged: function(scope, draggedRow) {},
-                rowDropped: function(scope, droppedRow, target) {},
+                rowDropped: function(scope, droppedRow, target, position) {},
                 rowOverRow: function(scope, draggedRow, row) {},
                 rowEnterRow: function(scope, draggedRow, row) {},
                 rowLeavesRow: function(scope, draggedRow, row) {},

--- a/js/draggable-rows.js
+++ b/js/draggable-rows.js
@@ -1,142 +1,171 @@
 (function() {
-    "use strict";
+    'use strict';
 
-    angular.module("ui.grid.draggable-rows", ["ui.grid"])
+    angular.module('ui.grid.draggable-rows', ['ui.grid'])
 
-        .constant("uiGridDraggableRowsConstants", {
-            featureName: "draggableRows",
-            ROW_OVER_CLASS: "ui-grid-draggable-row-over",
-            publicEvents: {
-                draggableRows: {
-                    rowDragged: function(scope, draggedRow) {},
-                    rowDropped: function(scope, droppedRow, target) {},
-                    rowOverRow: function(scope, draggedRow, row) {},
-                    rowEnterRow: function(scope, draggedRow, row) {},
-                    rowLeavesRow: function(scope, draggedRow, row) {},
-                    rowFinishDrag: function(scope) {}
-                }
+    .constant('uiGridDraggableRowsConstants', {
+        featureName: 'draggableRows',
+        ROW_OVER_CLASS: 'ui-grid-draggable-row-over',
+        ROW_OVER_ABOVE_CLASS: 'ui-grid-draggable-row-over--above',
+        ROW_OVER_BELOW_CLASS: 'ui-grid-draggable-row-over--below',
+        POSITION_ABOVE: 'above',
+        POSITION_BELOW: 'below',
+        publicEvents: {
+            draggableRows: {
+                rowDragged: function(scope, draggedRow) {},
+                rowDropped: function(scope, droppedRow, target) {},
+                rowOverRow: function(scope, draggedRow, row) {},
+                rowEnterRow: function(scope, draggedRow, row) {},
+                rowLeavesRow: function(scope, draggedRow, row) {},
+                rowFinishDrag: function(scope) {}
             }
-        })
+        }
+    })
 
-        .factory("uiGridDraggableRowsCommon", [function() {
-            return {
-                catchedRow: null
-            };
-        }])
+    .factory('uiGridDraggableRowsCommon', [function() {
+        return {
+            catchedRow: null,
+            position: null
+        };
+    }])
 
-        .service("uiGridDraggableRowsService", ["uiGridDraggableRowsConstants", function(uiGridDraggableRowsConstants) {
-            this.initializeGrid = function(grid, $scope, $element) {
-                grid.api.registerEventsFromObject(uiGridDraggableRowsConstants.publicEvents);
+    .service('uiGridDraggableRowsService', ['uiGridDraggableRowsConstants', function(uiGridDraggableRowsConstants) {
+        this.initializeGrid = function(grid, $scope, $element) {
+            grid.api.registerEventsFromObject(uiGridDraggableRowsConstants.publicEvents);
 
-                grid.api.draggableRows.on.rowFinishDrag($scope, function() {
-                    $element.find("." + uiGridDraggableRowsConstants.ROW_OVER_CLASS).removeClass(uiGridDraggableRowsConstants.ROW_OVER_CLASS);
+            grid.api.draggableRows.on.rowFinishDrag($scope, function() {
+                angular.forEach($element[0].querySelectorAll('.' + uiGridDraggableRowsConstants.ROW_OVER_CLASS), function(row) {
+                    row.classList.remove(uiGridDraggableRowsConstants.ROW_OVER_CLASS);
+                    row.classList.remove(uiGridDraggableRowsConstants.ROW_OVER_ABOVE_CLASS);
+                    row.classList.remove(uiGridDraggableRowsConstants.ROW_OVER_BELOW_CLASS);
                 });
-            };
-        }])
+            });
+        };
+    }])
 
-        .service("uiGridDraggableRowService", ["uiGridDraggableRowsConstants", "uiGridDraggableRowsCommon", function (uiGridDraggableRowsConstants, uiGridDraggableRowsCommon) {
-            this.prepareDraggableRow = function($scope, $element) {
-                var grid = $scope.grid;
-                var row = $element[0];
+    .service('uiGridDraggableRowService', ['uiGridDraggableRowsConstants', 'uiGridDraggableRowsCommon', function(uiGridDraggableRowsConstants, uiGridDraggableRowsCommon) {
+        this.prepareDraggableRow = function($scope, $element) {
+            var grid = $scope.grid;
+            var row = $element[0];
 
-                var listeners = {
-                    onDragOverEventListener: function (e) {
-                        if (e.preventDefault) {
-                            e.preventDefault();
-                        }
-
-                        e.dataTransfer.dropEffect = "move";
-                        grid.api.draggableRows.raise.rowOverRow(uiGridDraggableRowsCommon.catchedRow, this);
-                    },
-
-                    onDragStartEventListener: function (e) {
-                        uiGridDraggableRowsCommon.catchedRow = this;
-
-                        this.style.opacity = "0.5";
-                        e.dataTransfer.setData("text/plain", "start");
-
-                        grid.api.draggableRows.raise.rowDragged(this);
-                    },
-
-                    onDragLeaveEventListener: function () {
-                        this.style.opacity = "1";
-                        this.classList.remove(uiGridDraggableRowsConstants.ROW_OVER_CLASS);
-
-                        grid.api.draggableRows.raise.rowLeavesRow(uiGridDraggableRowsCommon.catchedRow, this);
-                    },
-
-                    onDragEnterEventListener: function() {
-                        this.classList.add(uiGridDraggableRowsConstants.ROW_OVER_CLASS);
-
-                        grid.api.draggableRows.raise.rowEnterRow(uiGridDraggableRowsCommon.catchedRow, this);
-                    },
-
-                    onDragEndEventListener: function () {
-                        grid.api.draggableRows.raise.rowFinishDrag();
-                    },
-
-                    onDropEventListener: function (e) {
-                        var catchedRow = uiGridDraggableRowsCommon.catchedRow;
-
-                        if (e.stopPropagation) {
-                            e.stopPropagation();
-                        }
-
-                        if (e.preventDefault) {
-                            e.preventDefault();
-                        }
-
-                        if(catchedRow === this) {
-                            return false;
-                        }
-
-                        grid.api.draggableRows.raise.rowDropped(catchedRow, this);
-
+            var listeners = {
+                onDragOverEventListener: function(e) {
+                    if (e.preventDefault) {
                         e.preventDefault();
                     }
-                };
 
-                row.addEventListener("dragover", listeners.onDragOverEventListener, false);
-                row.addEventListener("dragstart", listeners.onDragStartEventListener, false);
-                row.addEventListener("dragleave", listeners.onDragLeaveEventListener, false);
-                row.addEventListener("dragenter", listeners.onDragEnterEventListener, false);
-                row.addEventListener("dragend", listeners.onDragEndEventListener, false);
-                row.addEventListener("drop", listeners.onDropEventListener);
-            };
+                    var dataTransfer = e.dataTransfer || e.originalEvent.dataTransfer;
+                    dataTransfer.effectAllowed = 'copyMove';
+                    dataTransfer.dropEffect = 'move';
 
-        }])
+                    var offset = e.offsetY || e.layerY || (e.originalEvent ? e.originalEvent.offsetY : 0);
 
-        .directive("uiGridDraggableRow", ["uiGridDraggableRowService", function(uiGridDraggableRowService) {
-            return {
-                restrict: "ACE",
-                scope: {
-                    draggableId: "=",
-                    grid: "="
+                    $element.addClass(uiGridDraggableRowsConstants.ROW_OVER_CLASS);
+
+                    if (offset < this.offsetHeight / 2) {
+                        uiGridDraggableRowsCommon.position = uiGridDraggableRowsConstants.POSITION_ABOVE;
+
+                        $element.removeClass(uiGridDraggableRowsConstants.ROW_OVER_BELOW_CLASS);
+                        $element.addClass(uiGridDraggableRowsConstants.ROW_OVER_ABOVE_CLASS);
+
+                    } else {
+                        uiGridDraggableRowsCommon.position = uiGridDraggableRowsConstants.POSITION_BELOW;
+
+                        $element.removeClass(uiGridDraggableRowsConstants.ROW_OVER_ABOVE_CLASS);
+                        $element.addClass(uiGridDraggableRowsConstants.ROW_OVER_BELOW_CLASS);
+                    }
+
+                    grid.api.draggableRows.raise.rowOverRow(uiGridDraggableRowsCommon.catchedRow, this);
                 },
-                compile: function() {
-                    return {
-                        pre: function($scope, $element) {
-                            uiGridDraggableRowService.prepareDraggableRow($scope, $element);
-                        }
-                    };
-                }
-            };
-        }])
 
-        .directive("uiGridDraggableRows", ["uiGridDraggableRowsService", function (uiGridDraggableRowsService) {
-            return {
-                restrict: "A",
-                replace: true,
-                priority: 0,
-                require: "uiGrid",
-                scope: false,
-                compile: function () {
-                    return {
-                        pre: function ($scope, $element, $attrs, uiGridCtrl) {
-                            uiGridDraggableRowsService.initializeGrid(uiGridCtrl.grid, $scope, $element);
-                        }
-                    };
+                onDragStartEventListener: function(e) {
+                    this.style.opacity = '0.5';
+
+                    uiGridDraggableRowsCommon.catchedRow = this;
+
+                    grid.api.draggableRows.raise.rowDragged(this);
+                },
+
+                onDragLeaveEventListener: function() {
+                    this.style.opacity = '1';
+
+                    this.classList.remove(uiGridDraggableRowsConstants.ROW_OVER_CLASS);
+                    this.classList.remove(uiGridDraggableRowsConstants.ROW_OVER_ABOVE_CLASS);
+                    this.classList.remove(uiGridDraggableRowsConstants.ROW_OVER_BELOW_CLASS);
+
+                    grid.api.draggableRows.raise.rowLeavesRow(uiGridDraggableRowsCommon.catchedRow, this);
+                },
+
+                onDragEnterEventListener: function() {
+                    grid.api.draggableRows.raise.rowEnterRow(uiGridDraggableRowsCommon.catchedRow, this);
+                },
+
+                onDragEndEventListener: function() {
+                    grid.api.draggableRows.raise.rowFinishDrag();
+                },
+
+                onDropEventListener: function(e) {
+                    var catchedRow = uiGridDraggableRowsCommon.catchedRow;
+
+                    if (e.stopPropagation) {
+                        e.stopPropagation();
+                    }
+
+                    if (e.preventDefault) {
+                        e.preventDefault();
+                    }
+
+                    if (catchedRow === this) {
+                        return false;
+                    }
+
+                    grid.api.draggableRows.raise.rowDropped(catchedRow, this, uiGridDraggableRowsCommon.position);
+
+                    e.preventDefault();
                 }
             };
-        }]);
+
+            row.addEventListener('dragover', listeners.onDragOverEventListener, false);
+            row.addEventListener('dragstart', listeners.onDragStartEventListener, false);
+            row.addEventListener('dragleave', listeners.onDragLeaveEventListener, false);
+            row.addEventListener('dragenter', listeners.onDragEnterEventListener, false);
+            row.addEventListener('dragend', listeners.onDragEndEventListener, false);
+            row.addEventListener('drop', listeners.onDropEventListener);
+        };
+
+    }])
+
+    .directive('uiGridDraggableRow', ['uiGridDraggableRowService', function(uiGridDraggableRowService) {
+        return {
+            restrict: 'ACE',
+            scope: {
+                draggableId: '@',
+                grid: '='
+            },
+            compile: function() {
+                return {
+                    pre: function($scope, $element) {
+                        uiGridDraggableRowService.prepareDraggableRow($scope, $element);
+                    }
+                };
+            }
+        };
+    }])
+
+    .directive('uiGridDraggableRows', ['uiGridDraggableRowsService', function(uiGridDraggableRowsService) {
+        return {
+            restrict: 'A',
+            replace: true,
+            priority: 0,
+            require: 'uiGrid',
+            scope: false,
+            compile: function() {
+                return {
+                    pre: function($scope, $element, $attrs, uiGridCtrl) {
+                        uiGridDraggableRowsService.initializeGrid(uiGridCtrl.grid, $scope, $element);
+                    }
+                };
+            }
+        };
+    }]);
 }());

--- a/less/draggable-rows.less
+++ b/less/draggable-rows.less
@@ -3,13 +3,22 @@
 }
 
 .ui-grid-draggable-row-over {
-    color: #AAA;
+	position: relative;
 
     &:before {
-        content: ' ';
+        content: "";
         display: block;
-        padding-top: 5px;
-        height: 10px;
-        border: 1px dashed #AAA;
+        position: absolute;
+        left: 0;
+        width: 100%;
+        border-bottom: 1px dotted #AAA;
     }
+
+    &--above:before {
+    	top: 0;
+    }
+
+    &--below:before {
+    	bottom: 0;
+    }    
 }

--- a/scss/draggable-rows.scss
+++ b/scss/draggable-rows.scss
@@ -1,0 +1,24 @@
+.ui-grid-draggable-row {
+    height: 30px;
+}
+
+.ui-grid-draggable-row-over {
+	position: relative;
+
+    &:before {
+        content: "";
+        display: block;
+        position: absolute;
+        left: 0;
+        width: 100%;
+        border-bottom: 1px dotted #AAA;
+    }
+
+    &--above:before {
+    	top: 0;
+    }
+
+    &--below:before {
+    	bottom: 0;
+    }    
+}


### PR DESCRIPTION
Hi,

This PR adds position (above/below) to the plugin to improve styling and usability (i.e. you can prevent moving the row to an incorrect position).

I've also removed the dependency on jQuery in favour of Angular/jQLite.

I'm using this code in my drop handler now to determine the new position:

```js
var move = function(from, to) {
    /*jshint validthis: true */
    this.splice(to, 0, this.splice(from, 1)[0]);
};

gridApi.draggableRows.on.rowDropped($scope, function(dropped, target, position) {
    var droppedId = dropped.getAttribute('draggable-id'),
        targetId = target.getAttribute('draggable-id'),
        droppedIndex, targetIndex;

    data.forEach(function(row, i) {
        if (row.id === droppedId) {
            droppedIndex = i;
        }
        if (row.id === targetId) {
            targetIndex = i;
        }
    });

    var newIndex;

    if (position === 'above') {
        if (droppedIndex < targetIndex) {
            newIndex = targetIndex - 1;
        } else {
            newIndex = targetIndex;
        }
    } else {
        if (droppedIndex < targetIndex) {
            newIndex = targetIndex;
        } else {
            newIndex = targetIndex + 1;
        }
    }

    $timeout(function() {
        move.apply(data, [droppedIndex, newIndex]);
    });
});
```

Sorry for corrupting the whitespace - please let me know if its a big issue and I can try to fix it.

Thanks