### PR TITLE
Fix for when gridOptions.data is a string value

### DIFF
--- a/js/draggable-rows.js
+++ b/js/draggable-rows.js
@@ -46,7 +46,7 @@
         };
     }])
 
-    .service('uiGridDraggableRowService', ['uiGridDraggableRowsConstants', 'uiGridDraggableRowsCommon', function(uiGridDraggableRowsConstants, uiGridDraggableRowsCommon) {
+    .service('uiGridDraggableRowService', ['uiGridDraggableRowsConstants', 'uiGridDraggableRowsCommon', '$parse', function(uiGridDraggableRowsConstants, uiGridDraggableRowsCommon, $parse) {
         var move = function(from, to) {
             /*jshint validthis: true */
             this.splice(to, 0, this.splice(from, 1)[0]);
@@ -55,6 +55,8 @@
         this.prepareDraggableRow = function($scope, $element) {
             var grid = $scope.grid;
             var data = grid.options.data;
+            if (angular.isString(data))
+                data = $parse(data)(grid.appScope);
             var row = $element[0];
 
             var listeners = {


### PR DESCRIPTION
See: http://ui-grid.info/docs/#/api/ui.grid.class:GridOptions

>The most flexible usage is to set your data on $scope:
>
>$scope.data = data;
>
>And then direct the grid to resolve whatever is in $scope.data:
>
>$scope.gridOptions.data = 'data';
>
>This is the most flexible approach as it allows you to replace $scope.data whenever you feel like it without getting pointer issues.

This breaks draggable-rows.