### PR TITLE
Fixed a drag and drop issue with Firefox requiring to set some data i…

### DIFF
--- a/js/draggable-rows.js
+++ b/js/draggable-rows.js
@@ -93,7 +93,7 @@
 
                 onDragStartEventListener: function(e) {
                     this.style.opacity = '0.5';
-
+                    e.dataTransfer.setData('Text', 'move'); // Need to set some data for FF to work		
                     uiGridDraggableRowsCommon.draggedRow = this;
                     uiGridDraggableRowsCommon.draggedRowEntity = $scope.$parent.$parent.row.entity;
 


### PR DESCRIPTION
This change addresses the issue with FF drag-n-drop:
dragstart event listener needs to add some data to the dataTransfer object for Firefox to allow drag and drop:
                onDragStartEventListener: function(e) {
               ...
                    e.dataTransfer.setData('Text', 'move'); /