### PR TITLE
Added targetRow and targetRowEntity to the info object

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,11 @@ To listen these events just register new listener via _ui-grid_ API.
 {
     draggedRow: domElement,     // The dragged row element
 
-    draggedRowEntity: object,   // The object the row represents in the grid data (`row.entity`)
+    draggedRowEntity: object,   // The object the dragged row represents in the grid data (`row.entity`)
+    
+    targetRow: domElement,      // The target row element
+    
+    targetRowEntity: object,    // The object the target row represents in the grid data
 
     position: string,           // String that indicates whether the row was dropped
                                 // above or below the drop target (determined by half row height)

--- a/js/draggable-rows.js
+++ b/js/draggable-rows.js
@@ -26,6 +26,8 @@
         return {
             draggedRow: null,
             draggedRowEntity: null,
+            targetRow: null,
+            targetRowEntity: null,
             position: null,
             fromIndex: null,
             toIndex: null
@@ -142,6 +144,10 @@
                     }
 
                     uiGridDraggableRowsCommon.toIndex = data().indexOf($scope.$parent.$parent.row.entity);
+                    
+                    uiGridDraggableRowsCommon.targetRow = this;
+                    
+                    uiGridDraggableRowsCommon.targetRowEntity = $scope.$parent.$parent.row.entity;
 
                     if (uiGridDraggableRowsCommon.position === uiGridDraggableRowsConstants.POSITION_ABOVE) {
                         if (uiGridDraggableRowsCommon.fromIndex < uiGridDraggableRowsCommon.toIndex) {


### PR DESCRIPTION
I added the target row element and target row entity to the 'info' object returned by the rowDropped event. This is useful for when you need to access data from the target entity. Also updated the README. 