### PR TITLE
Adds support for `useUiGridDraggableRowsHandle` gridOptions property.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ $scope.gridOptions.onRegisterApi = function (gridApi) {
 };
 ```
 
+To enable using a "handle" for dragging the rows, add the `useUiGridDraggableRowsHandle` property to your gridOptions and add this class to your handle: `ui-grid-draggable-row-handle`.
+
+```js
+$scope.gridOptions.useUiGridDraggableRowsHandle = true;
+```
+
 ## Additional styling
 When you drag a row over others they get additional css class `ui-grid-draggable-row-over`. This plugin has default styling for these elements. If you are using __less__ you could import styles into your application.
 

--- a/js/draggable-rows.js
+++ b/js/draggable-rows.js
@@ -55,6 +55,9 @@
         this.prepareDraggableRow = function($scope, $element) {
             var grid = $scope.grid;
             var row = $element[0];
+            var hasHandle = $scope.grid.options.useUiGridDraggableHandle;
+            var currentTarget = null;
+            var handle = null;
 
             var data = function() {
                 if (angular.isString(grid.options.data)) {
@@ -65,6 +68,14 @@
             };
 
             var listeners = {
+                onMouseDownEventListener: function (e) {
+                    currentTarget = angular.element(e.target);
+                    handle = currentTarget.closest('.ui-grid-draggable-row-handle', $element)[0];
+                },
+                onMouseUpEventListener: function (e) {
+                    currentTarget = null;
+                    handle = null;
+                },
                 onDragOverEventListener: function(e) {
                     if (e.preventDefault) {
                         e.preventDefault();
@@ -95,6 +106,12 @@
                 },
 
                 onDragStartEventListener: function(e) {
+                    if (hasHandle && !handle) {
+                        e.stopPropagation();
+                        e.preventDefault();
+                        return false;
+                    }
+
                     this.style.opacity = '0.5';
                     e.dataTransfer.setData('Text', 'move'); // Need to set some data for FF to work		
                     uiGridDraggableRowsCommon.draggedRow = this;
@@ -162,6 +179,8 @@
                 }
             };
 
+            row.addEventListener('mousedown', listeners.onMouseDownEventListener, false);
+            row.addEventListener('mouseup', listeners.onMouseUpEventListener, false);
             row.addEventListener('dragover', listeners.onDragOverEventListener, false);
             row.addEventListener('dragstart', listeners.onDragStartEventListener, false);
             row.addEventListener('dragleave', listeners.onDragLeaveEventListener, false);


### PR DESCRIPTION
This update allows users to set an element to use as the "handle" for dragging rows. The rows will only be dragged from that element.