### PR TITLE
change direct style manipulation to css and ensure style is removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,30 +72,28 @@ When you drag a row over others they get additional css class `ui-grid-draggable
 If you are using clear css just put these styles into your stylesheet.
 
 ```css
+.ui-grid-draggable-row-target {
+  opacity: 0.5 !important;
+}
 .ui-grid-draggable-row {
-    height: 30px;
+  height: 30px;
 }
-
 .ui-grid-draggable-row-over {
-    position: relative;
-    color: #AAA;
+  position: relative;
 }
-
 .ui-grid-draggable-row-over:before {
-    content: "";
-    display: block;
-    position: absolute;
-    left: 0;
-    width: 100%;
-    border-bottom: 1px dashed #AAA;
+  content: "";
+  display: block;
+  position: absolute;
+  left: 0;
+  width: 100%;
+  border-bottom: 1px dotted #AAA;
 }
-
 .ui-grid-draggable-row-over--above:before {
-    top: 0;
+  top: 0;
 }
-
 .ui-grid-draggable-row-over--below:before {
-    bottom: 0;
+  bottom: 0;
 }
 ```
 
@@ -119,9 +117,9 @@ To listen these events just register new listener via _ui-grid_ API.
     draggedRow: domElement,     // The dragged row element
 
     draggedRowEntity: object,   // The object the dragged row represents in the grid data (`row.entity`)
-    
+
     targetRow: domElement,      // The target row element
-    
+
     targetRowEntity: object,    // The object the target row represents in the grid data
 
     position: string,           // String that indicates whether the row was dropped
@@ -178,9 +176,9 @@ $scope.gridData.onRegisterApi = function (gridApi) {
 
 ## Support
 
-[<img width="300" title="Codewave.eu" src="http://codewave.eu/assets/images/logo.svg">](http://codewave.eu) 
+[<img width="300" title="Codewave.eu" src="http://codewave.eu/assets/images/logo.svg">](http://codewave.eu)
 
-Project is currently maintained by [codewave.eu](http://codewave.eu). 
+Project is currently maintained by [codewave.eu](http://codewave.eu).
 
 ## Author
 Plugin **ui-grid-draggable-rows** has been originally developed by [Szymon Krajewski](https://github.com/skrajewski).

--- a/js/draggable-rows.js
+++ b/js/draggable-rows.js
@@ -5,6 +5,7 @@
 
     .constant('uiGridDraggableRowsConstants', {
         featureName: 'draggableRows',
+        ROW_TARGET_CLASS: 'ui-grid-draggable-row-target',
         ROW_OVER_CLASS: 'ui-grid-draggable-row-over',
         ROW_OVER_ABOVE_CLASS: 'ui-grid-draggable-row-over--above',
         ROW_OVER_BELOW_CLASS: 'ui-grid-draggable-row-over--below',
@@ -61,6 +62,9 @@
                     row.classList.remove(uiGridDraggableRowsConstants.ROW_OVER_CLASS);
                     row.classList.remove(uiGridDraggableRowsConstants.ROW_OVER_ABOVE_CLASS);
                     row.classList.remove(uiGridDraggableRowsConstants.ROW_OVER_BELOW_CLASS);
+                });
+                angular.forEach($element[0].querySelectorAll('.' + uiGridDraggableRowsConstants.ROW_TARGET_CLASS), function(row) {
+                    row.classList.remove(uiGridDraggableRowsConstants.ROW_TARGET_CLASS);
                 });
             });
         };
@@ -148,8 +152,8 @@
                         return false;
                     }
 
-                    this.style.opacity = '0.5';
-                    e.dataTransfer.setData('Text', 'move'); // Need to set some data for FF to work     
+                    this.classList.add(uiGridDraggableRowsConstants.ROW_TARGET_CLASS);
+                    e.dataTransfer.setData('Text', 'move'); // Need to set some data for FF to work
                     uiGridDraggableRowsCommon.draggedRow = this;
                     uiGridDraggableRowsCommon.draggedRowEntity = $scope.$parent.$parent.row.entity;
 
@@ -162,7 +166,7 @@
                 },
 
                 onDragLeaveEventListener: function() {
-                    this.style.opacity = '1';
+                    this.classList.remove(uiGridDraggableRowsConstants.ROW_TARGET_CLASS);
 
                     this.classList.remove(uiGridDraggableRowsConstants.ROW_OVER_CLASS);
                     this.classList.remove(uiGridDraggableRowsConstants.ROW_OVER_ABOVE_CLASS);
@@ -195,9 +199,9 @@
                     }
 
                     uiGridDraggableRowsCommon.toIndex = data().indexOf($scope.$parent.$parent.row.entity);
-                    
+
                     uiGridDraggableRowsCommon.targetRow = this;
-                    
+
                     uiGridDraggableRowsCommon.targetRowEntity = $scope.$parent.$parent.row.entity;
 
                     if (uiGridDraggableRowsCommon.position === uiGridDraggableRowsConstants.POSITION_ABOVE) {

--- a/less/draggable-rows.less
+++ b/less/draggable-rows.less
@@ -1,3 +1,7 @@
+.ui-grid-draggable-row-target {
+  opacity: 0.5 !important;
+}
+
 .ui-grid-draggable-row {
     height: 30px;
 }
@@ -20,5 +24,5 @@
 
     &--below:before {
     	bottom: 0;
-    }    
+    }
 }

--- a/scss/draggable-rows.scss
+++ b/scss/draggable-rows.scss
@@ -1,3 +1,7 @@
+.ui-grid-draggable-row-target {
+  opacity: 0.5 !important;
+}
+
 .ui-grid-draggable-row {
     height: 30px;
 }
@@ -20,5 +24,5 @@
 
     &--below:before {
     	bottom: 0;
-    }    
+    }
 }


### PR DESCRIPTION
Resolves #28 
From what I could tell, the direct styling was not always being removed correctly.  This patch switches to css classes and adds a hook to ensure everything is cleaned up correctly.