### PR TITLE
Add support for SVG elements in IE when using useUiGridDraggable

### DIFF
--- a/js/draggable-rows.js
+++ b/js/draggable-rows.js
@@ -106,7 +106,8 @@
 
             var listeners = {
                 onMouseDownEventListener: function (e) {
-                    currentTarget = angular.element(e.target);
+                    var eventTarget = e.target.correspondingUseElement || e.target;
+                    currentTarget = angular.element(eventTarget);
                     handle = currentTarget.closest('.' + uiGridDraggableRowsConstants.ROW_HANDLE_CLASS, $element)[0];
                 },
 


### PR DESCRIPTION
It is not possible to drag on SVG elements in IE when using the useUiGridDraggable property.

The issue is that IE returns the SVG DOM element on event.target (SVGElementInstance) instead of the element in the main DOM tree, this leads to the failure of .closest as it is searching in the incorrect tree.

The proposed solution is use e.target.correspondingUseElement if it is present, as the _use_ element is located in the correct tree.

More info here: [stackoverflow 33672395](http://stackoverflow.com/questions/33672395/use-within-svg-not-finding-closest-div-in-ie)