### PR TITLE
Changing drag start event to check draggable attribute before continuing

### DIFF
--- a/js/draggable-rows.js
+++ b/js/draggable-rows.js
@@ -152,7 +152,8 @@
                 },
 
                 onDragStartEventListener: function(e) {
-                    if (uiGridDraggableRowsSettings.dragDisabled || (hasHandle && !handle)) {
+                    if (uiGridDraggableRowsSettings.dragDisabled || (hasHandle && !handle) ||
+						!this.draggable) {
                         e.preventDefault();
                         e.stopPropagation();
 


### PR DESCRIPTION
On Macintosh using Chrome if some text in a row is highlighted the row inexplicably becomes draggable again. This check prevents this issue from occurring.