### PR TITLE
[Issue-58] Replaced .closest() method with native

### DIFF
--- a/js/draggable-rows.js
+++ b/js/draggable-rows.js
@@ -113,8 +113,7 @@
 
             var listeners = {
                 onMouseDownEventListener: function (e) {
-                    currentTarget = angular.element(e.target);
-                    handle = currentTarget.closest('.' + uiGridDraggableRowsConstants.ROW_HANDLE_CLASS, $element)[0];
+                    handle = e.target.closest('.' + uiGridDraggableRowsConstants.ROW_HANDLE_CLASS, $element);
                 },
 
                 onMouseUpEventListener: function (e) {


### PR DESCRIPTION
jsLite does not provide `.closest()` method.
Replaced with native `.closest()`.