### PR TITLE
Fix drag handler error

### DIFF
--- a/js/draggable-rows.js
+++ b/js/draggable-rows.js
@@ -113,8 +113,7 @@
 
             var listeners = {
                 onMouseDownEventListener: function (e) {
-                    currentTarget = angular.element(e.target);
-                    handle = currentTarget.closest('.' + uiGridDraggableRowsConstants.ROW_HANDLE_CLASS, $element)[0];
+                    handle = $element.find('.' + uiGridDraggableRowsConstants.ROW_HANDLE_CLASS, $element);
                 },
 
                 onMouseUpEventListener: function (e) {


### PR DESCRIPTION
Replaced `.closest()[0]` method with `.find()` as jqLite doesn't support method `.closest()`