### PR TITLE
Added removal of event listeners, to prevent memory leaks

### DIFF
--- a/js/draggable-rows.js
+++ b/js/draggable-rows.js
@@ -268,13 +268,13 @@
             }
 		
 	    $scope.$on('$destroy', function() {
-		row.removeEventListener('dragover', listeners.onDragOverEventListener, false);
+                row.removeEventListener('dragover', listeners.onDragOverEventListener, false);
                 row.removeEventListener('dragstart', listeners.onDragStartEventListener, false);
                 row.removeEventListener('dragleave', listeners.onDragLeaveEventListener, false);
                 row.removeEventListener('dragenter', listeners.onDragEnterEventListener, false);
                 row.removeEventListener('dragend', listeners.onDragEndEventListener, false);
                 row.removeEventListener('drop', listeners.onDropEventListener);
-		row.removeEventListener('mousedown', listeners.onMouseDownEventListener, false);
+                row.removeEventListener('mousedown', listeners.onMouseDownEventListener, false);
                 row.removeEventListener('mouseup', listeners.onMouseUpEventListener, false);
 	    });
         };

--- a/js/draggable-rows.js
+++ b/js/draggable-rows.js
@@ -267,7 +267,7 @@
                 row.addEventListener('mouseup', listeners.onMouseUpEventListener, false);
             }
 		
-	    $scope.$on('$destroy', function() {
+            $scope.$on('$destroy', function() {
                 row.removeEventListener('dragover', listeners.onDragOverEventListener, false);
                 row.removeEventListener('dragstart', listeners.onDragStartEventListener, false);
                 row.removeEventListener('dragleave', listeners.onDragLeaveEventListener, false);
@@ -276,7 +276,7 @@
                 row.removeEventListener('drop', listeners.onDropEventListener);
                 row.removeEventListener('mousedown', listeners.onMouseDownEventListener, false);
                 row.removeEventListener('mouseup', listeners.onMouseUpEventListener, false);
-	    });
+            });
         };
     }])
 

--- a/js/draggable-rows.js
+++ b/js/draggable-rows.js
@@ -266,6 +266,17 @@
                 row.addEventListener('mousedown', listeners.onMouseDownEventListener, false);
                 row.addEventListener('mouseup', listeners.onMouseUpEventListener, false);
             }
+		
+	    $scope.$on('$destroy', function() {
+		row.removeEventListener('dragover', listeners.onDragOverEventListener, false);
+                row.removeEventListener('dragstart', listeners.onDragStartEventListener, false);
+                row.removeEventListener('dragleave', listeners.onDragLeaveEventListener, false);
+                row.removeEventListener('dragenter', listeners.onDragEnterEventListener, false);
+                row.removeEventListener('dragend', listeners.onDragEndEventListener, false);
+                row.removeEventListener('drop', listeners.onDropEventListener);
+		row.removeEventListener('mousedown', listeners.onMouseDownEventListener, false);
+                row.removeEventListener('mouseup', listeners.onMouseUpEventListener, false);
+	    });
         };
     }])
 


### PR DESCRIPTION
When using `addEventListener`, the event handlers need to be removed manually on $scope.$destroy, otherwise memory leaks occur.