### PR TITLE
Fixed memory leak

### DIFF
--- a/js/draggable-rows.js
+++ b/js/draggable-rows.js
@@ -104,12 +104,12 @@
 
                 // issue #16
                 if (grid.api.hasOwnProperty('edit')) {
-                    grid.api.edit.on.beginCellEdit(null, function() {
+                    grid.api.edit.on.beginCellEdit($scope, function() {
                         draggableState = row.getAttribute('draggable');
                         row.setAttribute('draggable', false);
                     });
 
-                    grid.api.edit.on.afterCellEdit(null, function() {
+                    grid.api.edit.on.afterCellEdit($scope, function() {
                         row.setAttribute('draggable', draggableState);
                         draggableState = null;
                     });
@@ -177,7 +177,7 @@
                     if (uiGridDraggableRowsSettings.limitDropToSelf) {
                         e.dataTransfer.setData('gridId', getGridId($(e.currentTarget)));
                     }
-                    
+
                     uiGridDraggableRowsCommon.draggedRow = this;
                     uiGridDraggableRowsCommon.draggedRowEntity = $scope.$parent.$parent.row.entity;
 


### PR DESCRIPTION
UI-Grid only removes listeners automatically when the $scope is passed as argument.

The documentation on GridApi.prototype.registerEvent [1] states the following:
Scope is optional and can be a null value, but in this case you must deregister it yourself via the returned deregister function.

[1] https://github.com/angular-ui/ui-grid/blob/47c12394b0e8adf56a78e4e8b6a6f496554f910b/packages/core/src/js/factories/GridApi.js